### PR TITLE
docs(readme) Replace placeholders with _actual_ information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Kia ora koutou and haere mai to my GitHub page.
 
-## Statistics overview
-
-![ZZ-Cat's Stats](https://github-readme-stats.vercel.app/api?username=ZZ-Cat&theme=default&show_icons=true&hide_border=false&count_private=false)  
-![ZZ-Cat's Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=ZZ-Cat&theme=default&show_icons=true&hide_border=false&layout=compact)  
-![ZZ-Cat's Streak](https://github-readme-streak-stats.herokuapp.com/?user=ZZ-Cat&theme=default&hide_border=false)
-
 ## About me
 
 I am an independent firmware developer for free and open source embedded systems.  
@@ -29,3 +23,9 @@ In a project where I am unable to use Rust, it will be built with Python via one
 
 Having my start with the Arduino IDE in 2013, as this is what introduced me to C++, I now prefer to use PlatformIO due to its streamlined integrations and package managements _without_ being locked to one vendor over another.  
 However, this may change as I wind down my C++ projects and start creating newer embedded projects with Rust and Python.
+
+## Statistics overview
+
+![ZZ-Cat's Stats](https://github-readme-stats.vercel.app/api?username=ZZ-Cat&theme=default&show_icons=true&hide_border=false&count_private=false)  
+![ZZ-Cat's Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=ZZ-Cat&theme=default&show_icons=true&hide_border=false&layout=compact)  
+![ZZ-Cat's Streak](https://github-readme-streak-stats.herokuapp.com/?user=ZZ-Cat&theme=default&hide_border=false)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ My languages of choice are ordered with my most commonly used language first:
 1. C++
 2. Rust
 3. Python
+4. Expression2
+5. Lua
 
 C++ is the language I have spent the most time with since 2013. It is now a legacy language for me, and over time I amm discontinuing its use in my projects in favour of Rust and Python.  
 Rust is an _extremely new_ language to me. However, my newer projects will be built with Rust instead of C++.  

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Python also sees its uses as rapid prototyping, if I want to sketch up ideas and
 Having my start with the Arduino IDE in 2013, as this is what introduced me to C++, I now prefer to use PlatformIO due to its streamlined integrations and package managements _without_ being locked to one vendor over another.  
 However, this may change as I wind down my C++ projects and start creating newer embedded projects with Rust and Python.
 
+### Operating system
+
+As if I wasn't feeding into the stereotype hard enough... I happen to be a Linux user. =^/.~=  
+Pop!_OS, specifically. Been using this since 25th of February, 2024, and it's been amazing for me.
+
 ## Statistics overview
 
 ![ZZ-Cat's Stats](https://github-readme-stats.vercel.app/api?username=ZZ-Cat&theme=default&show_icons=true&hide_border=false&count_private=false)  

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ My languages of choice are ordered with my most commonly used language first:
 C++ is my dominant language of choice when it comes to writing firmware for embedded systems, and I have been using C++ since 2013.  
 For me, it _is_ a legacy language that I am branching away from in favour of learning memory-safe languages. For my existing C++ projects (suc as CRSF for Arduino) are still actively being maintained unless I have written otherwise in a particular repository.
 
+Expression2 to me is what I call a "toy language" in the sense that I use this as my practicing "playground" for my other languages... usually with C++.  
+Expression2 is a scripting language that's a hybrid of TypeScript and Lua, and it was once a _very popular_ scripting language in a physics sandbox game called Garry's Mod.  
+I still code in Expression2 every now and then, but it is a _significantly lower_ priority for me than my other projects. Examples of Expression2 is RailDriver and RLC Titanium.
+
+I cannot mention Expression2 without mentioning Lua.  
+Now... there _is a lot_ of crossovers between Lua and Expression2. So much so that the original writers of the Expression2 language have it show up as "Lua" in GitHub's Linguist language identification software. This is why you'll see Lua featured prominently in my statistics here, because that is _actually_ referring to my Expression2 projects, both past and present.
+
+Rust is set to replace C++ as my primary coding language of choice.  
+Now... currently, I don't have any repositories that feature Rust. However, this may change as time marches on.  
+My plan here is to use a flavour of Rust called Embedded Rust, and it's currently _completely_ unknown territory for me (which to me is fun and exciting... I love a challenge, and I love to learn new things, and I love to explore new concepts and ideas
+
+Snekky snek! Python!
+Whether you love it, loathe it, or hate it, I don't care. It's useful to me.  
+If I can't flash my primary language onto a particular target, _that_ target gets the snek.  
+Python also sees its uses as rapid prototyping, if I want to sketch up ideas and test them on-the-fly. However, it is not without its flaws, and some of these flaws are the reasons why it is my secondary language and _not_ right up there with C++ and Rust.
+
 ### Development Environments
 
 Having my start with the Arduino IDE in 2013, as this is what introduced me to C++, I now prefer to use PlatformIO due to its streamlined integrations and package managements _without_ being locked to one vendor over another.  

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ My focus is with robustness, reliability, and security. The latter of which I ta
 My languages of choice are ordered with my most commonly used language first:
 
 1. C++
-2. Rust
+2. Expression2
 3. Python
-4. Expression2
-5. Lua
+4. Lua
+5. Rust
 
 C++ is the language I have spent the most time with since 2013. It is now a legacy language for me, and over time I amm discontinuing its use in my projects in favour of Rust and Python.  
 Rust is an _extremely new_ language to me. However, my newer projects will be built with Rust instead of C++.  

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ My languages of choice are ordered with my most commonly used language first:
 4. Lua
 5. Rust
 
+C++ is my dominant language of choice when it comes to writing firmware for embedded systems, and I have been using C++ since 2013.  
+For me, it _is_ a legacy language that I am branching away from in favour of learning memory-safe languages. For my existing C++ projects (suc as CRSF for Arduino) are still actively being maintained unless I have written otherwise in a particular repository.
 
 ### Development Environments
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ My languages of choice are ordered with my most commonly used language first:
 4. Lua
 5. Rust
 
-C++ is the language I have spent the most time with since 2013. It is now a legacy language for me, and over time I amm discontinuing its use in my projects in favour of Rust and Python.  
-Rust is an _extremely new_ language to me. However, my newer projects will be built with Rust instead of C++.  
-In a project where I am unable to use Rust, it will be built with Python via one of its many flavours (EG CircuitPython, MicroPython etc).
 
 ### Development Environments
 


### PR DESCRIPTION
## Overview

I have replaced my placeholders about C++, Python and Rust with information that is accurate to my current state of development. In addition to this, I added some info about the fact that I'm a Linux user. Because why not?